### PR TITLE
CONFIG: Update NuGet dependencies and modernise ADotNet build/PR workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,6 @@ updates:
       prefix: "CONFIG"
     labels:
       - "dependencies"
+    ignore:
+        - dependency-name: "FluentAssertions"
+          versions: ["8.x", "9.x", "10.x", "*"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,6 @@ on:
     - synchronize
     - reopened
     - closed
-    branches:
-    - main
 env:
   IS_RELEASE_CANDIDATE: >-
     ${{
@@ -27,89 +25,16 @@ env:
       )
     }}
 jobs:
-  label:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Apply Label
-      uses: actions/github-script@v6
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        script: >-
-          const prefixes = [
-            'INFRA:',
-            'PROVISIONS:',
-            'RELEASES:',
-            'DATA:',
-            'BROKERS:',
-            'FOUNDATIONS:',
-            'PROCESSINGS:',
-            'ORCHESTRATIONS:',
-            'COORDINATIONS:',
-            'MANAGEMENTS:',
-            'AGGREGATIONS:',
-            'CONTROLLERS:',
-            'CLIENTS:',
-            'EXPOSERS:',
-            'PROVIDERS:',
-            'BASE:',
-            'COMPONENTS:',
-            'VIEWS:',
-            'PAGES:',
-            'ACCEPTANCE:',
-            'INTEGRATIONS:',
-            'CODE RUB:',
-            'MINOR FIX:',
-            'MEDIUM FIX:',
-            'MAJOR FIX:',
-            'DOCUMENTATION:',
-            'CONFIG:',
-            'STANDARD:',
-            'DESIGN:',
-            'BUSINESS:'
-          ];
-
-
-          const pullRequest = context.payload.pull_request;
-
-
-          if (!pullRequest) {
-            console.log('No pull request context available.');
-            return;
-          }
-
-
-          const title = context.payload.pull_request.title;
-
-          const existingLabels = context.payload.pull_request.labels.map(label => label.name);
-
-
-          for (const prefix of prefixes) {
-            if (title.startsWith(prefix)) {
-              const label = prefix.slice(0, -1);
-              if (!existingLabels.includes(label)) {
-                console.log(`Applying label: ${label}`);
-                await github.rest.issues.addLabels({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: context.payload.pull_request.number,
-                  labels: [label]
-                });
-              }
-              break;
-            }
-          }
-    permissions:
-      contents: read
-      pull-requests: write
-  Build:
+  build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
     - name: Enable long paths for Git
       run: git config --global core.longpaths true
     - name: Check Out
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
     - name: Setup Dot Net Version
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.x
     - name: Restore
@@ -134,7 +59,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'RELEASES')
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
       with:
         token: ${{ secrets.PAT_FOR_TAGGING }}
     - name: Configure Git
@@ -206,9 +131,9 @@ jobs:
     if: needs.add_tag.result == 'success'
     steps:
     - name: Check out
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
     - name: Setup .Net
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.x
     - name: Restore

--- a/.github/workflows/prLinter.yml
+++ b/.github/workflows/prLinter.yml
@@ -1,0 +1,174 @@
+name: PR Linter
+on:
+  pull_request:
+    types:
+    - opened
+    - edited
+    - synchronize
+    - reopened
+    - closed
+    branches:
+    - main
+jobs:
+  label:
+    name: Label
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    steps:
+    - name: Apply Label
+      uses: actions/github-script@v8
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: >-
+          const prefixes = [
+            'INFRA:',
+            'PROVISIONS:',
+            'RELEASES:',
+            'DATA:',
+            'BROKERS:',
+            'FOUNDATIONS:',
+            'PROCESSINGS:',
+            'ORCHESTRATIONS:',
+            'COORDINATIONS:',
+            'MANAGEMENTS:',
+            'AGGREGATIONS:',
+            'CONTROLLERS:',
+            'CLIENTS:',
+            'EXPOSERS:',
+            'PROVIDERS:',
+            'BASE:',
+            'COMPONENTS:',
+            'VIEWS:',
+            'PAGES:',
+            'ACCEPTANCE:',
+            'INTEGRATIONS:',
+            'CODE RUB:',
+            'MINOR FIX:',
+            'MEDIUM FIX:',
+            'MAJOR FIX:',
+            'DOCUMENTATION:',
+            'CONFIG:',
+            'STANDARD:',
+            'DESIGN:',
+            'BUSINESS:'
+          ];
+
+
+          const pullRequest = context.payload.pull_request;
+
+
+          if (!pullRequest) {
+            console.log('No pull request context available.');
+            return;
+          }
+
+
+          const title = context.payload.pull_request.title;
+
+          const existingLabels = context.payload.pull_request.labels.map(label => label.name);
+
+
+          for (const prefix of prefixes) {
+            if (title.startsWith(prefix)) {
+              const label = prefix.slice(0, -1);
+              if (!existingLabels.includes(label)) {
+                console.log(`Applying label: ${label}`);
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.pull_request.number,
+                  labels: [label]
+                });
+              }
+              break;
+            }
+          }
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+  requireIssueOrTask:
+    name: Require Issue Or Task Association
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out
+      uses: actions/checkout@v5
+    - name: Get PR Information
+      id: get_pr_info
+      uses: actions/github-script@v8
+      with:
+        script: >2-
+              const pr = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number
+              });
+
+              const prOwner = pr.data.user.login || "";
+              const prBody = pr.data.body || "";
+              core.setOutput("prOwner", prOwner);
+              core.setOutput("description", prBody);
+              console.log(`PR Owner: ${prOwner}`);
+              console.log(`PR Body: ${prBody}`);
+    - name: Check For Associated Issues Or Tasks
+      id: check_for_issues_or_tasks
+      if: ${{ !contains(',dependabot[bot],', format(',{0},', steps.get_pr_info.outputs.prOwner)) }}
+      env:
+        PR_BODY: ${{ steps.get_pr_info.outputs.description }}
+      run: >2-
+            if [[ -z "${PR_BODY:-}" ]]; then
+              echo "Error: PR description does not contain any links to issue(s)/task(s) (e.g., 'closes #123' / 'closes AB#123' / 'fixes #123' / 'fixes AB#123')."
+              exit 1
+            fi
+
+            NORMALIZED_PR_BODY=$(printf '%s' "$PR_BODY" | tr '\r\n' '  ' | tr -s ' ')
+
+            if printf '%s' "$NORMALIZED_PR_BODY" | grep -Piq "(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s*(\[#[0-9]+\]|#[0-9]+|\[AB#[0-9]+\]|AB#[0-9]+)"; then
+              echo "Valid PR description."
+            else
+              echo "Error: PR description does not contain any links to issue(s)/task(s) (e.g., 'closes #123' / 'closes AB#123' / 'fixes #123' / 'fixes AB#123')."
+              exit 1
+            fi
+      shell: bash
+    permissions:
+      contents: read
+      pull-requests: read
+  setAuthorAsPrAssignee:
+    name: Set Author As PR Assignee
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    steps:
+    - name: Set Author As PR Assignee
+      uses: actions/github-script@v8
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: >
+          const pr = context.payload.pull_request;
+
+          if (!pr) {
+            console.log('No pull request context available.');
+            return;
+          }
+
+
+          const author = pr.user.login;
+
+          if (author.endsWith('[bot]')) {
+            console.log(`Skipping bot author: ${author}`);
+            return;
+          }
+
+
+          console.log(`Assigning PR to author: ${author}`);
+
+
+          await github.rest.issues.addAssignees({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: pr.number,
+            assignees: [author]
+          });
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write

--- a/NHSISL.CsvHelperClient.Infrastructure/NHSISL.CsvHelperClient.Infrastructure.csproj
+++ b/NHSISL.CsvHelperClient.Infrastructure/NHSISL.CsvHelperClient.Infrastructure.csproj
@@ -10,7 +10,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="ADotNet" Version="4.3.0" />
+		<PackageReference Include="ADotNet" Version="5.0.0" />
 	</ItemGroup>
 
 </Project>

--- a/NHSISL.CsvHelperClient.Infrastructure/Program.cs
+++ b/NHSISL.CsvHelperClient.Infrastructure/Program.cs
@@ -20,6 +20,8 @@ namespace NHSISL.CsvHelperClient.Infrastructure
                 branchName: "main",
                 projectName: "NHSISL.CsvHelperClient",
                 dotNetVersion: "10.x");
+
+            scriptGenerationService.GeneratePrLintScript(branchName: "main");
         }
     }
 }

--- a/NHSISL.CsvHelperClient.Infrastructure/Services/ScriptGenerationService.cs
+++ b/NHSISL.CsvHelperClient.Infrastructure/Services/ScriptGenerationService.cs
@@ -5,7 +5,7 @@
 using ADotNet.Clients;
 using ADotNet.Models.Pipelines.GithubPipelines.DotNets;
 using ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks;
-using ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks.SetupDotNetTaskV3s;
+using ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks.SetupDotNetTaskV5s;
 
 namespace NHSISL.CsvHelperClient.Infrastructure.Services
 {
@@ -31,8 +31,7 @@ namespace NHSISL.CsvHelperClient.Infrastructure.Services
 
                     PullRequest = new PullRequestEvent
                     {
-                        Types = new string[] { "opened", "synchronize", "reopened", "closed" },
-                        Branches = new string[] { branchName }
+                        Types = new string[] { "opened", "synchronize", "reopened", "closed" }
                     }
                 },
 
@@ -45,13 +44,10 @@ namespace NHSISL.CsvHelperClient.Infrastructure.Services
                 Jobs = new Dictionary<string, Job>
                 {
                     {
-                        "label",
-                        new LabelJobV2(runsOn: BuildMachines.UbuntuLatest)
-                    },
-                    {
-                        "Build",
+                        "build",
                         new Job
                         {
+                            Name = "Build",
                             RunsOn = BuildMachines.UbuntuLatest,
 
                             Steps = new List<GithubTask>
@@ -62,16 +58,16 @@ namespace NHSISL.CsvHelperClient.Infrastructure.Services
                                     Run = "git config --global core.longpaths true"
                                 },
 
-                                new CheckoutTaskV3
+                                new CheckoutTaskV5
                                 {
                                     Name = "Check Out"
                                 },
 
-                                new SetupDotNetTaskV3
+                                new SetupDotNetTaskV5
                                 {
                                     Name = "Setup Dot Net Version",
 
-                                    With = new TargetDotNetVersionV3
+                                    With = new TargetDotNetVersionV5
                                     {
                                         DotNetVersion = dotNetVersion
                                     }
@@ -96,7 +92,7 @@ namespace NHSISL.CsvHelperClient.Infrastructure.Services
                     },
                     {
                         "add_tag",
-                        new TagJob(
+                        new TagJobV2(
                             runsOn: BuildMachines.UbuntuLatest,
                             dependsOn: "build",
                             projectRelativePath: $"{projectName}/{projectName}.csproj",
@@ -105,7 +101,7 @@ namespace NHSISL.CsvHelperClient.Infrastructure.Services
                     },
                     {
                         "publish",
-                        new PublishJobV2(
+                        new PublishJobV4(
                             runsOn: BuildMachines.UbuntuLatest,
                             dependsOn: "add_tag",
                             dotNetVersion: dotNetVersion,
@@ -115,6 +111,60 @@ namespace NHSISL.CsvHelperClient.Infrastructure.Services
             };
 
             string buildScriptPath = "../../../../.github/workflows/build.yml";
+            string directoryPath = Path.GetDirectoryName(buildScriptPath);
+
+            if (!Directory.Exists(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            adotNetClient.SerializeAndWriteToFile(
+                githubPipeline,
+                path: buildScriptPath);
+        }
+
+        public void GeneratePrLintScript(string branchName)
+        {
+            var githubPipeline = new GithubPipeline
+            {
+                Name = "PR Linter",
+
+                OnEvents = new Events
+                {
+                    PullRequest = new PullRequestEvent
+                    {
+                        Types = new string[] { "opened", "edited", "synchronize", "reopened", "closed" },
+                        Branches = new string[] { branchName }
+                    }
+                },
+
+                Jobs = new Dictionary<string, Job>
+                {
+                    {
+                        "label",
+                        new LabelJobV3(runsOn: BuildMachines.UbuntuLatest)
+                        {
+                            Name = "Label"
+                        }
+                    },
+                    {
+                        "requireIssueOrTask",
+                        new RequireIssueOrTaskJobV2(excludedAuthors: "dependabot[bot]")
+                        {
+                            Name = "Require Issue Or Task Association",
+                        }
+                    },
+                    {
+                        "setAuthorAsPrAssignee",
+                        new SetAuthorAsPrAssigneeJobV2(runsOn: BuildMachines.UbuntuLatest)
+                        {
+                            Name = "Set Author As PR Assignee",
+                        }
+                    },
+                }
+            };
+
+            string buildScriptPath = "../../../../.github/workflows/prLinter.yml";
             string directoryPath = Path.GetDirectoryName(buildScriptPath);
 
             if (!Directory.Exists(directoryPath))

--- a/NHSISL.CsvHelperClient.Tests.Acceptance/NHSISL.CsvHelperClient.Tests.Acceptance.csproj
+++ b/NHSISL.CsvHelperClient.Tests.Acceptance/NHSISL.CsvHelperClient.Tests.Acceptance.csproj
@@ -12,7 +12,7 @@
 		<PackageReference Include="CompareNETObjects" Version="4.84.0" />
 		<PackageReference Include="DeepCloner" Version="0.10.4" />
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="CleanMoq" Version="42.42.42" />

--- a/NHSISL.CsvHelperClient.Tests.Acceptance/NHSISL.CsvHelperClient.Tests.Acceptance.csproj
+++ b/NHSISL.CsvHelperClient.Tests.Acceptance/NHSISL.CsvHelperClient.Tests.Acceptance.csproj
@@ -13,7 +13,7 @@
 		<PackageReference Include="DeepCloner" Version="0.10.4" />
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="CleanMoq" Version="42.42.42" />
 		<PackageReference Include="Tynamix.ObjectFiller" Version="1.5.9" />

--- a/NHSISL.CsvHelperClient.Tests.Acceptance/NHSISL.CsvHelperClient.Tests.Acceptance.csproj
+++ b/NHSISL.CsvHelperClient.Tests.Acceptance/NHSISL.CsvHelperClient.Tests.Acceptance.csproj
@@ -14,7 +14,7 @@
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="CleanMoq" Version="42.42.42" />
 		<PackageReference Include="Tynamix.ObjectFiller" Version="1.5.9" />
 		<PackageReference Include="Xeption" Version="2.9.0" />

--- a/NHSISL.CsvHelperClient.Tests.Integration/NHSISL.CsvHelperClient.Tests.Integration.csproj
+++ b/NHSISL.CsvHelperClient.Tests.Integration/NHSISL.CsvHelperClient.Tests.Integration.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
 	  <PackageReference Include="DeepCloner" Version="0.10.4" />
 	  <PackageReference Include="FluentAssertions" Version="[7.2.2]" />
-	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 	<PackageReference Include="Tynamix.ObjectFiller" Version="1.5.9" />
 	<PackageReference Include="xunit.v3" Version="3.2.2" />
 	<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/NHSISL.CsvHelperClient.Tests.Unit/NHSISL.CsvHelperClient.Tests.Unit.csproj
+++ b/NHSISL.CsvHelperClient.Tests.Unit/NHSISL.CsvHelperClient.Tests.Unit.csproj
@@ -12,7 +12,7 @@
 		<PackageReference Include="CompareNETObjects" Version="4.84.0" />
 		<PackageReference Include="DeepCloner" Version="0.10.4" />
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="CleanMoq" Version="42.42.42" />

--- a/NHSISL.CsvHelperClient.Tests.Unit/NHSISL.CsvHelperClient.Tests.Unit.csproj
+++ b/NHSISL.CsvHelperClient.Tests.Unit/NHSISL.CsvHelperClient.Tests.Unit.csproj
@@ -13,7 +13,7 @@
 		<PackageReference Include="DeepCloner" Version="0.10.4" />
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="CleanMoq" Version="42.42.42" />
 		<PackageReference Include="Tynamix.ObjectFiller" Version="1.5.9" />

--- a/NHSISL.CsvHelperClient.Tests.Unit/NHSISL.CsvHelperClient.Tests.Unit.csproj
+++ b/NHSISL.CsvHelperClient.Tests.Unit/NHSISL.CsvHelperClient.Tests.Unit.csproj
@@ -14,7 +14,7 @@
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="CleanMoq" Version="42.42.42" />
 		<PackageReference Include="Tynamix.ObjectFiller" Version="1.5.9" />
 		<PackageReference Include="Xeption" Version="2.9.0" />

--- a/NHSISL.CsvHelperClient/NHSISL.CsvHelperClient.csproj
+++ b/NHSISL.CsvHelperClient/NHSISL.CsvHelperClient.csproj
@@ -51,7 +51,7 @@
 
 	<ItemGroup>
 	  <PackageReference Include="CsvHelper" Version="33.1.0" />
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
 	  <PackageReference Include="Xeption" Version="2.9.0" />
 	</ItemGroup>
 


### PR DESCRIPTION
## Summary
Brings CsvHelperClient up to the .NET 10 modernisation standard.

closes [AB#29736](https://dev.azure.com/NELAnalytics/aef6c175-110f-4ba4-82fc-70761f459236/_workitems/edit/29736)

### Dependency updates (CONFIG)
- Microsoft.Extensions.DependencyInjection 10.0.8 -> 10.0.9
- Microsoft.Extensions.Configuration 10.0.8 -> 10.0.9
- Microsoft.Extensions.Configuration.Json 10.0.8 -> 10.0.9
- Microsoft.NET.Test.Sdk 18.5.1 -> 18.7.0
- ADotNet 4.3.0 -> 5.0.0
- dependabot: add FluentAssertions ignore rule (locked at [7.2.2])

### Workflow modernisation (CODE RUB)
- ADotNet components -> latest (CheckoutTaskV5 / SetupDotNetTaskV5 / LabelJobV3 / TagJobV2 / PublishJobV4); build.yml now on Node-24 actions (checkout@v5, setup-dotnet@v5, github-script@v8)
- Added prLinter.yml (Label, Require Issue Or Task, Set Author As PR Assignee, branch-filtered); moved the label job out of build.yml
- Fixed build job-id casing (Build -> build) to match the needs: reference

### Validation
- Build: 0 errors, 0 obsolete warnings
- Tests: 38 pass (9 Acceptance + 29 Unit)
- Vulnerable packages: none
- Workflows regenerated from the Infrastructure project (not hand-edited), idempotent
