### PR TITLE
CONFIG: Update NuGet dependencies to latest stable

### DIFF
--- a/NHSISL.CsvHelperClient.Tests.Acceptance/NHSISL.CsvHelperClient.Tests.Acceptance.csproj
+++ b/NHSISL.CsvHelperClient.Tests.Acceptance/NHSISL.CsvHelperClient.Tests.Acceptance.csproj
@@ -14,7 +14,7 @@
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="CleanMoq" Version="42.42.42" />
 		<PackageReference Include="Tynamix.ObjectFiller" Version="1.5.9" />
 		<PackageReference Include="Xeption" Version="2.9.0" />

--- a/NHSISL.CsvHelperClient.Tests.Acceptance/NHSISL.CsvHelperClient.Tests.Acceptance.csproj
+++ b/NHSISL.CsvHelperClient.Tests.Acceptance/NHSISL.CsvHelperClient.Tests.Acceptance.csproj
@@ -13,7 +13,7 @@
 		<PackageReference Include="DeepCloner" Version="0.10.4" />
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="CleanMoq" Version="42.42.42" />
 		<PackageReference Include="Tynamix.ObjectFiller" Version="1.5.9" />

--- a/NHSISL.CsvHelperClient.Tests.Integration/NHSISL.CsvHelperClient.Tests.Integration.csproj
+++ b/NHSISL.CsvHelperClient.Tests.Integration/NHSISL.CsvHelperClient.Tests.Integration.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
 	  <PackageReference Include="DeepCloner" Version="0.10.4" />
 	  <PackageReference Include="FluentAssertions" Version="[7.2.2]" />
-	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 	<PackageReference Include="Tynamix.ObjectFiller" Version="1.5.9" />
 	<PackageReference Include="xunit.v3" Version="3.2.2" />
 	<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/NHSISL.CsvHelperClient.Tests.Unit/NHSISL.CsvHelperClient.Tests.Unit.csproj
+++ b/NHSISL.CsvHelperClient.Tests.Unit/NHSISL.CsvHelperClient.Tests.Unit.csproj
@@ -14,7 +14,7 @@
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="CleanMoq" Version="42.42.42" />
 		<PackageReference Include="Tynamix.ObjectFiller" Version="1.5.9" />
 		<PackageReference Include="Xeption" Version="2.9.0" />

--- a/NHSISL.CsvHelperClient.Tests.Unit/NHSISL.CsvHelperClient.Tests.Unit.csproj
+++ b/NHSISL.CsvHelperClient.Tests.Unit/NHSISL.CsvHelperClient.Tests.Unit.csproj
@@ -13,7 +13,7 @@
 		<PackageReference Include="DeepCloner" Version="0.10.4" />
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="CleanMoq" Version="42.42.42" />
 		<PackageReference Include="Tynamix.ObjectFiller" Version="1.5.9" />


### PR DESCRIPTION
## Summary
NuGet currency pass for CsvHelperClient - brings every unpinned package to latest stable (Component Versions dashboard -> green). Supersedes dependabot #54/#55 (they will auto-close on merge).

closes [AB#29736](https://dev.azure.com/NELAnalytics/aef6c175-110f-4ba4-82fc-70761f459236/_workitems/edit/29736)

### Dependency updates (CONFIG, one per commit)
- Microsoft.Extensions family 10.0.9 -> 10.0.10 (Configuration, Configuration.Json, DependencyInjection - coupled family, one commit)
- Microsoft.NET.Test.Sdk 18.7.0 -> 18.8.1

### Validation (local)
- Build Release: 0 errors (each bump build-gated)
- dotnet list package --vulnerable --include-transitive: none
- ADotNet already 5.1.0 with the hardened prLinter (env: PR_BODY) - no regen needed
- FluentAssertions remains locked [7.2.2]; CleanMoq 42.42.42 is the internal pin (not on public sources)